### PR TITLE
Update skyblock_tips.snbt

### DIFF
--- a/config/ftbquests/quests/chapters/skyblock_tips.snbt
+++ b/config/ftbquests/quests/chapters/skyblock_tips.snbt
@@ -506,12 +506,9 @@
 			}],
 			rewards: [{
 				id: "2DBF52D6FA12240A",
-				type: "command",
-				title: "/skyblock create",
-				icon: "astralsorcery:tree_beacon",
-				auto: "no_toast",
-				command: "/skyblock create",
-				player_command: true
+				type: "xp",
+				auto: "enabled",
+				xp: 100
 			}]
 		},
 		{


### PR DESCRIPTION
Remove the "/skyblock create" command from the rewards and replace with 100 xp. The "/skyblock create" command is very disruptive to games in progress, leading to hours of bridge building or a restore if the reward is clicked and cheats are off.  Fixes issue #372